### PR TITLE
A little Cleanup

### DIFF
--- a/DaffittTech.NetworkStatus/DaffittTech.NetworkStatus.csproj
+++ b/DaffittTech.NetworkStatus/DaffittTech.NetworkStatus.csproj
@@ -53,8 +53,4 @@
 		</None>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Folder Include="wwwroot\css\" />
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
A little Cleanup

#### PR Classification
Code cleanup to remove unused folder references from the project file.

#### PR Summary
This pull request removes an unused folder reference from the project file to streamline the project configuration.
- `DaffittTech.NetworkStatus.csproj`: Removed the `<ItemGroup>` containing the `<Folder Include="wwwroot\css\" />` entry.
