### PR TITLE
Removed Sample image from README.md file because NuGet will not allow images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,3 @@ If you are placing your UI content and @code content in the same .razor page rem
 ```csharp
 @implements IDisposable
 ```
-
-### Sample Screen Shot
-![Sample Screen Shot](https://github.com/user-attachments/assets/e99bbd97-5fff-49dc-8b98-cf4e78ba2e93)
-


### PR DESCRIPTION
## No More Image
Removed Sample image from README.md file because NuGet will not allow images.


#### PR Classification  
Documentation  

#### PR Summary  
This pull request updates the `README.md` file to improve documentation for `.razor` pages and removes an outdated screenshot.  
- `README.md`: Added guidance on using `@implements IDisposable` in `.razor` pages.  
- `README.md`: Removed a sample screenshot linked to an external asset.  
